### PR TITLE
Adjust splash setup order

### DIFF
--- a/app/src/main/java/com/example/safetyhelper/SplashActivity.kt
+++ b/app/src/main/java/com/example/safetyhelper/SplashActivity.kt
@@ -13,6 +13,8 @@ import com.google.firebase.auth.FirebaseAuth
 class SplashActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // 1) SplashScreen 적용
+        installSplashScreen()
         super.onCreate(savedInstanceState)
 
         // 2) Edge-to-edge 설정


### PR DESCRIPTION
## Summary
- invoke `installSplashScreen()` before `super.onCreate`
- reorder step numbers for onboarding comments

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f61cddebc832d9c57eafe1fb23bbe